### PR TITLE
Update course sidebar settings migration

### DIFF
--- a/tables/courses.rb
+++ b/tables/courses.rb
@@ -33,7 +33,7 @@ class CourseTable < BaseTable
         column :is_open => :enrollable
 
         column :assessment_categories do
-          migrate_settings(old, new)
+          migrate_sidebar_settings(old, new)
           build_assessment_categories(old, new)
         end
 
@@ -105,36 +105,39 @@ class CourseTable < BaseTable
     [default_category, mission_category]
   end
 
-  def migrate_settings(source, destination)
+  def migrate_sidebar_settings(source, destination)
+    # V1 Mission and Training sidebar items are migrated in build_assessment_categories
+    # V1 Guilds sidebar items are dropped
+    # V1 Comics sidebar items are dropped
+
     mapping = {
       'announcements' => { sidebar_key: :announcements, # Key for sidebar settings
-                           component_settings_key: :announcement, # Key for concrete component settings
                            component_key: :course_announcements_component, # Component index settings
                            default_name: 'Announcements'},
       'achievements' => { sidebar_key: :achievements,
-                          component_settings_key: nil,
                           component_key: :course_achievements_component,
                           default_name: 'Achievements'},
       'leaderboard' => { sidebar_key: :leaderboard,
-                         component_settings_key: :leaderboard,
                          component_key: :course_leaderboard_component,
                          default_name: 'Leaderboard'},
       'students' => { sidebar_key: :users,
-                      component_settings_key: nil,
-                      component_key: nil,
+                      component_key: :course_users_component, # To be named more specifically later
                       default_name: 'Students'},
+      'submissions' => { sidebar_key: :assessments_submissions,
+                         component_key: :sidebar_assessments_submissions, # To be placed under assessments later
+                         default_name: 'Submissions'},
       'lesson_plan' => { sidebar_key: :lesson_plan,
-                         component_settings_key: nil,
                          component_key: :course_lesson_plan_component,
                          default_name: 'Lesson Plan'},
       'materials' => { sidebar_key: :materials,
-                       component_settings_key: :material,
                        component_key: :course_materials_component,
                        default_name: 'Materials'},
       'forums' => { sidebar_key: :forums,
-                    component_settings_key: :forum,
                     component_key: :course_forums_component,
-                    default_name: 'Forums'}
+                    default_name: 'Forums'},
+      'surveys' => { sidebar_key: :surveys,
+                     component_key: :course_survey_component,
+                     default_name: 'Surveys'},
     }
     source.course_navbar_preferences.each do |nav_pref|
       key = nav_pref.item
@@ -143,23 +146,24 @@ class CourseTable < BaseTable
       # Sidebar order
       destination.settings(:sidebar, item_hash[:sidebar_key]).weight = nav_pref.pos
 
-      if component_settings_key = item_hash[:component_settings_key]
-        # Handle individual component settings here
-        if nav_pref.name != item_hash[:default_name]
-          destination.settings(component_settings_key).title = nav_pref.name
-        end
-      end
-
       if component_key = item_hash[:component_key]
         # Component enable/disable settings
         destination.settings(:components, component_key).enabled = nav_pref.is_enabled
+
+        # Handle individual component settings here
+        if nav_pref.name != item_hash[:default_name]
+          destination.settings(component_key).title = nav_pref.name
+        end
       end
     end
   end
 end
 
 
-# V1:
+######
+# V1 #
+######
+
 # create_table "courses", :force => true do |t|
 #   t.string   "title"
 #   t.integer  "creator_id"
@@ -177,7 +181,66 @@ end
 #   t.boolean  "is_pending_deletion", :default => false
 # end
 
-# V2:
+# V1 course settings related tables
+#
+# create_table "course_preferences", :force => true do |t|
+#   t.integer  "course_id"
+#   t.integer  "preferable_item_id"
+#   t.string   "prefer_value"
+#   t.boolean  "display"
+#   t.datetime "created_at",         :null => false
+#   t.datetime "updated_at",         :null => false
+# end
+#
+# create_table "preferable_items", :force => true do |t|
+#   t.string   "item"
+#   t.string   "item_type"
+#   t.string   "name"
+#   t.string   "default_value"
+#   t.boolean  "default_display"
+#   t.string   "description"
+#   t.datetime "created_at",      :null => false
+#   t.datetime "updated_at",      :null => false
+# end
+#
+# create_table "course_navbar_preferences", :force => true do |t|
+#   t.integer  "course_id"
+#   t.integer  "navbar_preferable_item_id"
+#   t.integer  "navbar_link_type_id"
+#   t.string   "item"
+#   t.string   "name"
+#   t.boolean  "is_displayed"
+#   t.boolean  "is_enabled"
+#   t.string   "description"
+#   t.string   "link_to"
+#   t.integer  "pos"
+#   t.datetime "created_at",                :null => false
+#   t.datetime "updated_at",                :null => false
+# end
+#
+# create_table "navbar_preferable_items", :force => true do |t|
+#   t.string   "item"
+#   t.integer  "navbar_link_type_id"
+#   t.string   "name"
+#   t.boolean  "is_displayed"
+#   t.boolean  "is_enabled"
+#   t.string   "description"
+#   t.string   "link_to"
+#   t.integer  "pos"
+#   t.datetime "created_at",          :null => false
+#   t.datetime "updated_at",          :null => false
+# end
+#
+# create_table "navbar_link_types", :force => true do |t|
+#   t.string   "link_type"
+#   t.datetime "created_at", :null => false
+#   t.datetime "updated_at", :null => false
+# end
+
+######
+# V2 #
+######
+
 # create_table "courses", force: :cascade do |t|
 #   t.integer  "instance_id",      :null=>false, :index=>{:name=>"fk__courses_instance_id"}, :foreign_key=>{:references=>"instances", :name=>"fk_courses_instance_id", :on_update=>:no_action, :on_delete=>:no_action}
 #   t.string   "title",            :limit=>255, :null=>false
@@ -196,3 +259,55 @@ end
 #   t.datetime "updated_at",       :null=>false
 # end
 
+# Target course settings shape:
+#
+# {"components"=>
+#   {"course_points_disbursement_component"=>{"enabled"=>true},
+#    "course_announcements_component"=>{"enabled"=>true},
+#    "course_lesson_plan_component"=>{"enabled"=>true},
+#    "course_forums_component"=>{"enabled"=>true},
+#    "course_duplication_component"=>{"enabled"=>true},
+#    "course_statistics_component"=>{"enabled"=>true},
+#    "course_levels_component"=>{"enabled"=>true},
+#    "course_assessments_component"=>{"enabled"=>true},
+#    "course_discussion_topics_component"=>{"enabled"=>true},
+#    "course_groups_component"=>{"enabled"=>true},
+#    "course_leaderboard_component"=>{"enabled"=>true},
+#    "course_materials_component"=>{"enabled"=>true},
+#    "course_achievements_component"=>{"enabled"=>true},
+#    "course_courses_component"=>{"enabled"=>false},
+#    "course_users_component"=>{"enabled"=>false},
+#    "course_videos_component"=>{"enabled"=>true},
+#    "course_survey_component"=>{"enabled"=>true},
+#    "course_virtual_classrooms_component"=>{"enabled"=>false}},
+#
+#  "sidebar"=>
+#   {"assessments"=>{"weight"=>3},
+#    "announcements"=>{"weight"=>3},
+#    "assessments_submissions"=>{"weight"=>4},
+#    "videos"=>{"weight"=>5},
+#    "achievements"=>{"weight"=>6},
+#    "discussion_topics"=>{"weight"=>7},
+#    "leaderboard"=>{"weight"=>8},
+#    "users"=>{"weight"=>9},
+#    "lesson_plan"=>{"weight"=>10},
+#    "materials"=>{"weight"=>11},
+#    "forums"=>{"weight"=>12},
+#    "surveys"=>{"weight"=>13}},
+#
+#  "course"=>{"advance_start_at_duration"=>14 days},
+#  "user"=>{"title"=>"Students list"},
+#
+#  "course_announcements_component"=>
+#     {"title"=>"The announcements", "pagination"=>"50"},
+#  "course_forums_component"=>{"title"=>"chatterbox", "pagination"=>"50"},
+#  "course_leaderboard_component"=>
+#   {"title"=>"The leaderboard",
+#    "display_user_count"=>"30",
+#    "group_leaderboard"=>{"enabled"=>false}},
+#  "course_materials_component"=>{"title"=>"Workbin"},
+#  "course_virtual_classrooms_component"=>
+#   {"pagination"=>"50",
+#    "braincert_whiteboard_api_key"=>"xxxxxxxxxxx",
+#    "max_duration"=>"60"},
+#  }


### PR DESCRIPTION
Complete migration of v1's `course_navbar_preferences` to v2. For #30.

- V1 sidebar settings for guilds and comics are not migrated
- Sidebar titles for 'Students' is stored as the title for the users component for now.
- Sidebar titles for 'Submissions' is stored under a temporary key for now.