### PR TITLE
Migrate text response keyword and exact match solutions

### DIFF
--- a/migrators/course_migrator.rb
+++ b/migrators/course_migrator.rb
@@ -94,6 +94,8 @@ class CourseMigrator
         AssessmentMcqAnswerTable,
         AssessmentMcqAnswerOptionTable,
         AssessmentTrqAnswerTable,
+        AssessmentScribingAnswerTable,
+        AssessmentAnswerScribbleTable,
         AssessmentProgrammingAnswerTable,
 
         AssessmentSkillGroupTable,

--- a/migrators/course_migrator.rb
+++ b/migrators/course_migrator.rb
@@ -87,6 +87,8 @@ class CourseMigrator
         AssessmentMcqQuestionTable,
         AssessmentMcqOptionTable,
         AssessmentTrqQuestionTable,
+        AssessmentTrqKeywordSolutionTable,
+        AssessmentTrqExactMatchSolutionTable,
         AssessmentScribingQuestionTable,
         AssessmentProgrammingQuestionTable,
 

--- a/models/assessment_general_question.rb
+++ b/models/assessment_general_question.rb
@@ -15,4 +15,42 @@ module V1
         )
     end
   end
+
+  def_model 'assessment_auto_grading_exact_options' do
+    belongs_to :general_question, class_name: 'AssessmentGeneralQuestion', inverse_of: nil
+
+    scope :within_courses, ->(course_ids) do
+      joins(general_question: { assessment_question: :assessments }).
+        where(
+          {
+            general_question: {
+              assessment_question: {
+                assessments: {
+                  course_id: Array(course_ids)
+                }
+              }
+            }
+          }
+        )
+    end
+  end
+
+  def_model 'assessment_auto_grading_keyword_options' do
+    belongs_to :general_question, class_name: 'AssessmentGeneralQuestion', inverse_of: nil
+
+    scope :within_courses, ->(course_ids) do
+      joins(general_question: { assessment_question: :assessments }).
+        where(
+          {
+            general_question: {
+              assessment_question: {
+                assessments: {
+                  course_id: Array(course_ids)
+                }
+              }
+            }
+          }
+        )
+    end
+  end
 end

--- a/tables/assessment_trq_solutions.rb
+++ b/tables/assessment_trq_solutions.rb
@@ -1,0 +1,85 @@
+class AssessmentTrqKeywordSolutionTable < BaseTable
+  table_name 'assessment_auto_grading_keyword_options'
+  scope { |ids| within_courses(ids) }
+
+  def migrate_batch(batch)
+    batch.each do |old|
+      new = ::Course::Assessment::Question::TextResponseSolution.new
+      
+      migrate(old, new) do
+        column :question_id do
+          store.get(V1::AssessmentGeneralQuestion.table_name, old.general_question_id)
+        end
+        column :solution_type do
+          # [:exact_match, :keyword]
+          :keyword
+        end
+        column :keyword => :solution
+        column :score => :grade
+
+        skip_saving_unless_valid
+        
+        store.set(model.table_name, old.id, new.id)
+      end
+    end
+  end
+end
+
+class AssessmentTrqExactMatchSolutionTable < BaseTable
+  table_name 'assessment_auto_grading_exact_options'
+  scope { |ids| within_courses(ids) }
+
+  def migrate_batch(batch)
+    batch.each do |old|
+      new = ::Course::Assessment::Question::TextResponseSolution.new
+
+      # TODO: Add correct column in v2
+      # Only migrate the correct options since v2 do not support incorrect match
+      next if !old.correct
+
+      migrate(old, new) do
+        column :question_id do
+          store.get(V1::AssessmentGeneralQuestion.table_name, old.general_question_id)
+        end
+        column :solution_type do
+          # [:exact_match, :keyword]
+          :exact_match
+        end
+        column :answer => :solution
+        column :grade do
+          # V1 don't have grade for each option, give the max grade of the question
+          Course::Assessment::Question::TextResponse.find(new.question_id).maximum_grade
+        end
+
+        skip_saving_unless_valid
+
+        store.set(model.table_name, old.id, new.id)
+      end
+    end
+  end
+end
+
+# Schema
+#
+# V2:
+# create_table "course_assessment_question_text_response_solutions", force: :cascade do |t|
+#   t.integer "question_id",   :null=>false, :index=>{:name=>"fk__course_assessment_text_response_solution_question"}, :foreign_key=>{:references=>"course_assessment_question_text_responses", :name=>"fk_course_assessment_questi_2fbeabfad04f21c2d05c8b2d9100d1c4", :on_update=>:no_action, :on_delete=>:no_action}
+#   t.integer "solution_type", :default=>0, :null=>false
+#   t.text    "solution",      :null=>false
+#   t.decimal "grade",         :precision=>4, :scale=>1, :default=>0.0, :null=>false
+#   t.text    "explanation"
+# end
+
+# V1
+# create_table "assessment_auto_grading_exact_options", :force => true do |t|
+#   t.integer "general_question_id"
+#   t.boolean "correct"
+#   t.text    "answer"
+#   t.text    "explanation"
+# end
+#
+# create_table "assessment_auto_grading_keyword_options", :force => true do |t|
+#   t.integer "general_question_id"
+#   t.string  "keyword"
+#   t.integer "score"
+# end


### PR DESCRIPTION
Fix #31 

Note that V1 also supports negative exact match, those records have a `false` `correct` column, they are dropped currently. To discuss how to implement this in v2