### PR TITLE
Migrate submission file uploads

### DIFF
--- a/extensions/type_mapping.rb
+++ b/extensions/type_mapping.rb
@@ -13,6 +13,7 @@ TYPE_MAPPING = {
   'Achievement' => V1::Achievement.name,
   'Level' => V1::Level.name,
   'Assessment' => V1::Assessment.name,
+  'Assessment::Submission' => V1::AssessmentSubmission.name,
   'AsmReq' => V1::AsmReq.name,
   'Material' => V1::Material.name
 }

--- a/models/assessment.rb
+++ b/models/assessment.rb
@@ -11,6 +11,11 @@ module V1
     def specific
       as_assessment
     end
+
+    def file_upload_enabled?
+      as_assessment_type == 'Assessment::Mission' &&
+        specific && (specific.file_submission || specific.file_submission_only)
+    end
   end
 
   ::Course::Assessment.class_eval do

--- a/models/assessment_submission.rb
+++ b/models/assessment_submission.rb
@@ -3,6 +3,7 @@ module V1
     belongs_to :assessment, inverse_of: nil
     belongs_to :std_course, class_name: 'UserCourse', inverse_of: nil
     has_many :gradings, class_name: 'AssessmentGrading', foreign_key: 'submission_id', inverse_of: nil
+    has_many :file_uploads, as: :owner, inverse_of: nil
 
     scope :within_courses, ->(course_ids) do
       joins(:assessment).where({assessment: { course_id: course_ids }}).includes(gradings: :exp_transaction)

--- a/tables/assessments.rb
+++ b/tables/assessments.rb
@@ -85,6 +85,10 @@ class AssessmentTable < BaseTable
           end
         end
 
+        if old.file_upload_enabled?
+          new.questions << build_file_upload_question(new).acting_as
+        end
+
         skip_saving_unless_valid
 
         store.set(model.table_name, old.id, new.id)
@@ -117,6 +121,18 @@ class AssessmentTable < BaseTable
     new_name = name_generator.create while names_taken.include?(new_name.downcase)
 
     new_name
+  end
+
+  def build_file_upload_question(assessment)
+    question = Course::Assessment::Question::TextResponse.new(hide_text: true, allow_attachment: true)
+    question.title = 'File Upload'
+    question.maximum_grade = 0
+    question.weight = 100 # using a higher weight to make it last
+    question.created_at = assessment.created_at
+    question.updated_at = assessment.created_at
+    question.creator_id = assessment.creator_id
+    question.updater_id = assessment.creator_id
+    question
   end
 end
 


### PR DESCRIPTION
Fix #7 

There're no tables for them in v1, so I created the question/answer together with assessment/submission.