### PR TITLE
Migrate course settings

### DIFF
--- a/models/course.rb
+++ b/models/course.rb
@@ -1,8 +1,11 @@
 module V1
   def_model 'course_navbar_preferences'
 
+  def_model 'course_preferences'
+
   def_model 'courses' do
     has_many :course_navbar_preferences, inverse_of: nil
+    has_many :course_preferences, inverse_of: nil
 
     def training_pref
       @training_pref ||= course_navbar_preferences.where(item: 'trainings').first ||
@@ -22,6 +25,204 @@ module V1
 
     def root_folder
       @root_folder ||= MaterialFolder.find_by(course_id: id, parent_folder_id: nil)
+    end
+
+    # Each course has a CoursePreference for each of the 68 PreferableItems.
+    # A setting might be stored in the `prefer_value` field, `display` boolean or both;
+    # The `display` is typically to indicate whether a feature is enabled or not.
+    # For ease of understanding, we use the key :enabled instead.
+    def preference_hash
+      @preference_hash ||= course_preferences.to_a.map do |pref|
+        [pref.preferable_item_id, { value: pref.prefer_value, enabled: pref.display }]
+      end.to_h
+    end
+
+    # The preference_items_hash tags each relevant setting to a human-readable key.
+    # PreferableItems are list below in the following format:
+    #   [id, item, item_type, name, default_value, default_display]
+    def preference_items_hash
+      @preference_items_hash ||= {
+        # Mission page table headers and visibilities
+          # [1, "Mission", "Column", "title", "Mission", true],
+          # [2, "Mission", "Column", "tag", "Tag", true],
+          # [3, "Mission", "Column", "exp", "Max Exp", true],
+          # [4, "Mission", "Column", "award", "Requirement for", true],
+          # [5, "Mission", "Column", "start", "Start Time", true],
+          # [6, "Mission", "Column", "end", "End Time", true],
+        mission_column_header_title: [1, :value],
+        mission_column_header_tag: [2, :value],
+        mission_column_header_exp: [3, :value],
+        mission_column_header_award: [4, :value],
+        mission_column_header_start: [5, :value],
+        mission_column_header_end: [6, :value],
+
+        mission_column_show_title: [1, :enabled],
+        # mission_column_show_tag: [2, :enabled]   # Set to true in v2 since not yet implemented.
+        mission_column_show_exp: [3, :enabled],
+        mission_column_show_award: [4, :enabled],
+        mission_column_show_start: [5, :enabled],
+        mission_column_show_end: [6, :enabled],
+
+        # Training page table headers and visibilities
+          # [7, "Training", "Column", "title", "Training", true],
+          # [8, "Training", "Column", "tag", "Tag", true],
+          # [9, "Training", "Column", "exp", "Max Exp", true],
+          # [10, "Training", "Column", "award", "Requirement for", true],
+          # [11, "Training", "Column", "start", "Start Time", true],
+          # [12, "Training", "Column", "end", "End Time", false],
+          # [34, "Training", "Column", "bonus-exp", "Bonus EXP", true],
+          # [35, "Training", "Column", "bonus-cutoff", "Bonus Cutoff", true],
+        training_column_header_title: [7, :value],
+        training_column_header_tag: [8, :value],
+        training_column_header_exp: [9, :value],
+        training_column_header_award: [10, :value],
+        training_column_header_start: [11, :value],
+        training_column_header_end: [12, :value],
+        training_column_header_bonus_exp: [34, :value],
+        training_column_header_bonus_cutoff: [35, :value],
+
+        training_column_show_title: [7, :enabled],
+        # training_column_show_tag: [8, :enabled],  # Set to true in v2 since not yet implemented.
+        training_column_show_exp: [9, :enabled],
+        training_column_show_award: [10, :enabled],
+        training_column_show_start: [11, :enabled],
+        training_column_show_end: [12, :enabled],
+        training_column_show_bonus_exp: [34, :enabled],
+        training_column_show_bonus_cutoff: [35, :enabled],
+
+        # Sidebar settings have already been migrated from course_navbar_preferences
+          # [13, "Sidebar", "Student", "announcements", "Announcements", true],
+          # [14, "Sidebar", "Student", "missions", "Missions", true],
+          # [15, "Sidebar", "Student", "trainings", "Trainings", true],
+          # [16, "Sidebar", "Student", "submissions", "Submissions", true],
+          # [17, "Sidebar", "Student", "achievements", "Achievements", true],
+          # [18, "Sidebar", "Student", "leaderboard", "Leaderboard", true],
+          # [19, "Sidebar", "Student", "students", "Students", true],
+          # [31, "Sidebar", "Student", "comments", "Comments", true],
+          # [58, "Sidebar", "Student", "surveys", "Surveys", true],
+          # [59, "Sidebar", "Student", "materials", "Workbin", true],
+          # [60, "Sidebar", "Student", "lesson_plan", "Lesson Plan", true],
+          # [61, "Sidebar", "Student", "forums", "Forums", true],
+          # [64, "Sidebar", "Student", "comics", "Comics", true],
+
+        # Assessment DateTime format
+        # Dropdown menu: one of "%d-%m-%Y", "%d %b %Y %H:%M", "%d-%m-%Y %H:%M:%S", "ago"
+          # [20, "Training", "Time", "time_format", "%d-%m-%Y", true], # 30 not default
+          # [21, "Mission", "Time", "time_format", "%d-%m-%Y", true], # 26 not default
+        training_datetime_format: [20, :value],
+        mission_datetime_format: [21, :value],
+
+        # Email notification settings
+          # [22, "Email", "Course", "new_comment", "New Comment", true], - Notify user when someone commented on his/her thread
+          # [23, "Email", "Course", "new_grading", "New Grading", true], - Notify student for new available mission grading
+          # [24, "Email", "Course", "new_submission", "New Submission", true], - Notify student's tutor for new mission submission
+          # [25, "Email", "Course", "new_student", "New Student", true], - Notify students when their enrollment request is approved
+          # [26, "Email", "Course", "new_enroll_request", "New Enroll Request", true], - Notify lecturer(s) for new enrollment request
+          # [27, "Email", "Course", "new_announcement", "New Announcement", true], - Notify all staff and students for new announcement
+          # [28, "Email", "Course", "new_mission", "New Mission", true], - Notify all staff and students for new mission available
+          # [29, "Email", "Course", "new_training", "New Training", true], - Notify all staff and students for new training available
+          # [30, "Email", "Course", "mission_due", "Mission Reminder", true], - Mission due reminder for students who didn't submit yet
+        email_new_comment: [22, :enabled],
+        email_new_grading: [23, :enabled],
+        email_new_submission: [24, :enabled],
+        email_new_student: [25, :enabled],
+        email_new_enroll_request: [26, :enabled],
+        email_new_announcement: [27, :enabled],
+        email_new_mission: [28, :enabled],
+        email_new_training: [29, :enabled],
+        email_mission_due: [30, :enabled],
+
+        # MCQ Autograder - either "default" or "two-one-zero"
+          # [32, "Mcq", "AutoGrader", "title", "default", true],
+        multiple_choice_question_auto_grader_type: [32, :value],
+
+        # Enable Re-attempt allows students to do training again to get a fraction of the full EXP.
+          # [33, "Training", "Re-attempt", "title", "20", true],
+        training_reattempt_allowed: [33, :enabled],
+        training_reattempt_percentage_earnable: [33, :value],
+
+        #  Number of students to show in leaderboard
+          # [36, "Leaderboard", "Display", "leaders", "10", true],
+        leaderboard_student_count: [36, :value],
+
+        # Course homepage settings
+          # [37, "CourseHome", "Section", "announcements", "Announcements", true],
+          # [38, "CourseHome", "Section", "activities", "Notable Happenings", true],
+          # [41, "CourseHome", "SectionShow", "announcements_no", "3", true],
+          # [42, "CourseHome", "SectionShow", "activities_no", "50", true],
+        homepage_show_announcements: [37, :enabled],
+        homepage_show_activity_feed: [38, :enabled],
+        homepage_show_announcements_title: [37, :value],
+        homepage_show_activity_feed_title: [38, :value],
+        homepage_announcement_count: [41, :value],
+        homepage_activity_feed_count: [42, :value],
+
+        # Unused
+          # [39, "Training", "Table", "paging", "10", true],
+          # [40, "Mission", "Table", "paging", "10", true],
+          # [43, "Announcements", "List", "paging", "10", true],
+
+        # Locked achievements icon display type: Display gray scaled icon( A locked icon will be displayed if unchecked )
+          # [44, "Achievements", "Icon", "locked", "", true],
+        achievements_display_greyed_icon_instead_of_lock: [44, :enabled],
+
+        # Pagination settings
+          # [45, "Paging", "Announcements", "Announcements", "50", true], - Number of announcements to display per page
+          # [46, "Paging", "Missions", "Missions", "50", true], - Number of missions to display per page
+          # [47, "Paging", "MissionStats", "Mission Statistics", "50", true],
+          #    - Number of submission to display on page that lists all submissions for a particular mission.
+          # [48, "Paging", "Trainings", "Trainings", "50", true], - Number of trainings to display per page
+          # [49, "Paging", "TrainingStats", "Training Statistics", "50", true], - Number of students to display per page
+          #    - Number of submission to display on page that lists all submissions for a particular training.
+          # [50, "Paging", "MissionSubmissions", "Mission Submissions", "50", true],
+          #    - Number of submission to display on page that lists all missions submission in the course
+          # [51, "Paging", "TrainingSubmissions", "Training Submissions", "50", true],
+          #    - Number of submission to display on page that lists all training submission in the course
+          # [52, "Paging", "Comments", "Comments", "50", true], - Number of topics to display per page
+          # [53, "Paging", "Achievements", "Achievements", "50", true], - Number of achievements to display per page
+          # [54, "Paging", "Students", "Students", "50", true], - Number of students to display per page
+          # [55, "Paging", "ManageStudents", "Manage Students", "50", true], - Number of students to display per page
+          # [56, "Paging", "StudentSummary", "Student Summary", "50", true], - Number of students to display per page
+          # [62, "Paging", "Forums", "Forums", "20", true], - Number of topics to display per forum page
+        # Not that important. Port only those settings which have been implemented.
+        paginate_announcements_count: [45, :value],
+        paginate_comments_count: [52, :value],
+        paginate_forums_count: [62, :value],
+
+        # Auto create submissions for missions, special feature for courses that just want to take advantage of Coursemology's social features
+        # Courses enabled: [20, 28, 73, 96, 145, 180, 182, 225, 261, 292, 365, 385, 460, 529, 550, 572, 590, 606]
+          # [57, "Mission", "Submission", "auto", "", false],
+        # Ignore for now
+
+        # Display student's level and achievement status on sidebar?
+          # [63, "Sidebar", "Other", "ranking", "", true],
+        # Courses disabled: [27, 73, 124, 157, 165, 210, 286, 369, 556]
+        #   Most of these are clones of NUS CS2020
+        # In each case, it is easily argued that the intent is to turn off gamification altogether.
+        sidebar_show_gamification_elements: [63, :enabled],
+
+        # Allow PDF exporting
+          # [65, "Mission", "Export", "pdf", "PDF", false],
+          # [66, "Training", "Export", "pdf", "PDF", false],
+        mission_allow_pdf_export: [65, :enabled],
+        training_allow_pdf_export: [66, :enabled],
+
+        # Allow students to change their names within course
+          # [67, "UserCourse", "ChangeName", "ChangeName", "", true],
+        allow_course_user_change_name: [67, :enabled],
+
+        # Self Directed Learning
+        # Allow students to attempt the assessments that start at a future time provided they have fulfilled the prerequisites
+          # [68, "Assessment", "StartAt", "IgnoreStartAt", "", false]
+        self_directed_learning: [68, :enabled],
+      }
+    end
+
+    # Looks up the course setting for the given preference item name
+    # @param [Symbol] pref_item_name
+    def pref(pref_item_name)
+      id, key = preference_items_hash[pref_item_name]
+      preference_hash[id][key]
     end
   end
 

--- a/tables/courses.rb
+++ b/tables/courses.rb
@@ -37,6 +37,10 @@ class CourseTable < BaseTable
           build_assessment_categories(old, new)
         end
 
+        column :gamified do
+          old.pref(:sidebar_show_gamification_elements)
+        end
+
         column :start_at do
           old.start_at || old.created_at
         end
@@ -58,10 +62,226 @@ class CourseTable < BaseTable
         level.created_at = old.created_at
         level.updated_at = old.updated_at
 
+        # settings required mission category id, so save once before migrating settings
         skip_saving_unless_valid
+        if new.persisted?
+          migrate_settings(old, new)
+          new.save!
+        end
+
         store.set(model.table_name, old.id, new.id)
       end
     end
+  end
+
+  # Insert each CoursePreference setting into the destination course setting tree.
+  def migrate_settings(source, destination)
+    # Allow each assessment category to be set independently
+    training_category_id = destination.assessment_categories.find_by(title: source.training_pref.name).id.to_s
+    mission_category_id = destination.assessment_categories.find_by(title: source.mission_pref.name).id.to_s
+
+    # Generates a hash that is meant to be merged into a subtree of the course settings tree.
+    # Settings that match the default setting for a given key are ignored.
+    #
+    # Example:
+    # mapping = [
+    #   [:v1_funky_setting_key, :v2_key, "default value"],
+    #   [:v1_funky_setting_key2, :v2_key2, "default value 2"],
+    #   ...
+    # ]
+    # intermediate_keys = [:a, :b, :c]
+    #
+    # Returned value, if values are not the default:
+    # {
+    #   v2_key: { a: { b: { c: source.pref(:v1_funky_setting_key) } } },
+    #   v2_key2: { a: { b: { c: source.pref(:v1_funky_setting_key2) } } },
+    #   ...
+    # }
+    #
+    # @param [Array] mapping
+    # @param [Array] intermediate_keys
+    # @return [Hash]
+    non_default_settings_hash = -> (mapping, intermediate_keys) do
+      mapping.reduce({}) do |settings, setting_item|
+        old_key, new_key, default = setting_item
+        value = source.pref(old_key)
+        if value == default
+          settings
+        else
+          nested_value = intermediate_keys.reverse.reduce(value) { |acc, key| { key => acc } }
+          settings.merge({ new_key => nested_value })
+        end
+      end
+    end
+
+    # Sets the settings on the destination course if it is not the default setting.
+    set_unless_default = -> (key_array, source_setting_key, default_value) do
+      value = source.pref(source_setting_key)
+      destination.settings(*key_array[0...-1]).public_send("#{key_array.last}=", value) unless value == default_value
+    end
+
+    ###################################
+    # Migrate Training page table settings
+    ###################################
+    training_column_header_mapping = [
+      [:training_column_header_title, :title, "Training"],
+      [:training_column_header_tag, :skills, "Tag"],
+      [:training_column_header_exp, :base_exp, "Max Exp"],
+      [:training_column_header_award, :requirement_for, "Requirement for"],
+      [:training_column_header_start, :start_at, "Start Time"],
+      [:training_column_header_end, :end_at, "End Time"],
+      [:training_column_header_bonus_exp, :time_bonus_exp, "Bonus EXP"],
+      [:training_column_header_bonus_cutoff, :bonus_end_at, "Bonus Cutoff"],
+    ]
+    training_column_visibility_mapping = [
+      [:training_column_show_title, :title, true],
+      [:training_column_show_exp, :base_exp, true],
+      [:training_column_show_award, :requirement_for, true],
+      [:training_column_show_start, :start_at, true],
+      [:training_column_show_end, :end_at, false],
+      [:training_column_show_bonus_exp, :time_bonus_exp, true],
+      [:training_column_show_bonus_cutoff, :bonus_end_at, true],
+    ]
+    training_column_headers = non_default_settings_hash.call(training_column_header_mapping, [:header])
+    training_column_visibilities = non_default_settings_hash.call(training_column_visibility_mapping, [:visible])
+    training_columns = training_column_headers.deep_merge(training_column_visibilities)
+    destination.settings(:course_assessments_component, training_category_id).columns = training_columns unless training_columns.empty?
+
+    ###################################
+    # Migrate Mission page table settings
+    ###################################
+    mission_column_header_mapping = [
+      [:mission_column_header_title, :title, "Mission"],
+      [:mission_column_header_tag, :skills, "Tag"],
+      [:mission_column_header_exp, :base_exp, "Max Exp"],
+      [:mission_column_header_award, :requirement_for, "Requirement for"],
+      [:mission_column_header_start, :start_at, "Start Time"],
+      [:mission_column_header_end, :end_at, "End Time"],
+    ]
+
+    mission_column_visibility_mapping = [
+      [:mission_column_show_title, :title, true],
+      [:mission_column_show_exp, :base_exp, true],
+      [:mission_column_show_award, :requirement_for, true],
+      [:mission_column_show_start, :start_at, true],
+      [:mission_column_show_end, :end_at, true],
+    ]
+    mission_column_headers = non_default_settings_hash.call(mission_column_header_mapping, [:header])
+    mission_column_visibilities = non_default_settings_hash.call(mission_column_visibility_mapping, [:visible])
+    mission_columns = mission_column_headers.deep_merge(mission_column_visibilities)
+    destination.settings(:course_assessments_component, mission_category_id).columns = mission_columns unless mission_columns.empty?
+
+    ######################################
+    # Migrate Assessment Datetime Formats
+    ######################################
+    set_unless_default.call([:course_assessments_component, mission_category_id, :datetime_format], :mission_datetime_format, '%d-%m-%Y')
+    set_unless_default.call([:course_assessments_component, training_category_id, :datetime_format], :training_datetime_format, '%d-%m-%Y')
+
+    ###################################
+    # Migrate Email Settings
+    ###################################
+    training_email_mapping = [
+      [:email_new_comment, :new_comment, true],
+      [:email_new_mission, :assessment_opened, true],
+    ]
+    training_email_defaults = {
+      grades_released: { enabled: false },
+      new_submission: { enabled: false },
+      assessment_closing: { enabled: false }
+    }
+    training_emails = non_default_settings_hash.call(training_email_mapping, [:enabled]).merge(training_email_defaults)
+    destination.settings(:course_assessments_component, training_category_id).emails = training_emails
+
+    mission_email_mapping = [
+      [:email_new_comment, :new_comment, true],
+      [:email_new_grading, :grades_released, true],
+      [:email_new_submission, :new_submission, true],
+      [:email_new_training, :assessment_opened, true],
+      [:email_mission_due, :assessment_closing, true],
+    ]
+    mission_emails = non_default_settings_hash.call(mission_email_mapping, [:enabled])
+    destination.settings(:course_assessments_component, mission_category_id).emails = mission_emails unless mission_emails.empty?
+
+    # Notify students when their enrollment request is approved
+    set_unless_default.call([:course_users_component, :emails, :enrol_request_approved, :enabled], :email_new_student, true)
+    # Notify lecturer(s) for new enrollment request
+    set_unless_default.call([:course_users_component, :emails, :new_enrol_request, :enabled], :email_new_enroll_request, true)
+    # Notify all staff and students for new announcement
+    set_unless_default.call([:course_announcements_component, :emails, :new_announcement, :enabled], :email_new_announcement, true)
+
+    ###################################
+    # Migrate MCQ auto-grader settings
+    ###################################
+    set_unless_default.call(
+      [:course_assessments_component, training_category_id, :autograder_type],
+      :multiple_choice_question_auto_grader_type, 'default'
+    )
+
+    ###################################
+    # Migrate training Reattempt settings
+    ###################################
+    set_unless_default.call(
+      [:course_assessments_component, training_category_id, :reattempt_allowed],
+      :training_reattempt_allowed, true
+    )
+    # There are some negative values, though in each case, reattempt is disabled.
+    reattempt_percentage_earnable = source.pref(:training_reattempt_percentage_earnable).to_i
+    unless reattempt_percentage_earnable == 20
+      destination.settings(:course_assessments_component, training_category_id).reattempt_percentage_earnable =
+        [reattempt_percentage_earnable, 0].max
+    end
+
+    ###################################
+    # Migrate Leaderboard student count
+    ###################################
+    set_unless_default.call([:course_leaderboard_component, :display_user_count], :leaderboard_student_count, "10")
+
+    ###################################
+    # Migrate Course Homepage Settings
+    ###################################
+    set_unless_default.call([:course, :homepage, :announcements, :enabled], :homepage_show_announcements, true)
+    set_unless_default.call([:course, :homepage, :announcements, :count], :homepage_announcement_count, "3")
+    set_unless_default.call([:course, :homepage, :announcements, :title], :homepage_show_announcements_title, "Announcements")
+    set_unless_default.call([:course, :homepage, :activity_feed, :enabled], :homepage_show_activity_feed, true)
+    set_unless_default.call([:course, :homepage, :activity_feed, :count], :homepage_activity_feed_count, "50")
+    set_unless_default.call([:course, :homepage, :activity_feed, :title], :homepage_show_activity_feed_title, "Notable Happenings")
+
+    ###################################
+    # Migrate Achievement locked icon setting
+    ###################################
+    set_unless_default.call(
+      [:course_achievements_component, :show_greyscale_badge],
+      :achievements_display_greyed_icon_instead_of_lock, true
+    )
+
+    ###################################
+    # Migrate pagination setting
+    ###################################
+    set_unless_default.call([:course_announcements_component, :pagination], :paginate_announcements_count, '50')
+    set_unless_default.call([:course_discussion_topics_component, :pagination], :paginate_comments_count, '50')
+    set_unless_default.call([:course_forums_component, :pagination], :paginate_forums_count, '20')
+
+    ###################################
+    # Migrate PDF export setting
+    ###################################
+    set_unless_default.call(
+      [:course_assessments_component, mission_category_id, :allow_pdf_export],
+      :mission_allow_pdf_export, false
+    )
+    set_unless_default.call(
+      [:course_assessments_component, training_category_id, :allow_pdf_export],
+      :training_allow_pdf_export, false
+    )
+
+    ###################################
+    # Migrate course user name change setting
+    ###################################
+    set_unless_default.call([:course_users_component, :allow_course_user_change_name], :allow_course_user_change_name, true)
+
+    ###################################
+    # Migrate Self Directed Learning setting
+    ###################################
+    destination.settings(:course).advance_start_at_duration = 366.days if source.pref(:self_directed_learning)
   end
 
   def build_assessment_categories(source, destination)
@@ -69,9 +289,8 @@ class CourseTable < BaseTable
       raise 'No category or more than 1 categories found'
     end
 
-    default_category = destination.assessment_categories.first
     training_pref = source.training_pref
-
+    default_category = destination.assessment_categories.first
     default_category.assign_attributes(
       title: training_pref.name,
       weight: training_pref.pos,
@@ -149,6 +368,7 @@ class CourseTable < BaseTable
       if component_key = item_hash[:component_key]
         # Component enable/disable settings
         destination.settings(:components, component_key).enabled = nav_pref.is_enabled
+        destination.settings(:components, component_key).visible = nav_pref.is_displayed
 
         # Handle individual component settings here
         if nav_pref.name != item_hash[:default_name]
@@ -263,7 +483,10 @@ end
 #
 # {"components"=>
 #   {"course_points_disbursement_component"=>{"enabled"=>true},
-#    "course_announcements_component"=>{"enabled"=>true},
+#    "course_announcements_component"=>{
+#     "enabled"=>true,
+#     "visible"=>ture,                                                   # added for all components
+#    },
 #    "course_lesson_plan_component"=>{"enabled"=>true},
 #    "course_forums_component"=>{"enabled"=>true},
 #    "course_duplication_component"=>{"enabled"=>true},
@@ -295,11 +518,16 @@ end
 #    "forums"=>{"weight"=>12},
 #    "surveys"=>{"weight"=>13}},
 #
-#  "course"=>{"advance_start_at_duration"=>14 days},
+#  "course"=>{
+#    "advance_start_at_duration"=>14 days
+#    "homepage"=>{...}                                                   # new
+#   },
 #  "user"=>{"title"=>"Students list"},
 #
-#  "course_announcements_component"=>
-#     {"title"=>"The announcements", "pagination"=>"50"},
+#  "course_announcements_component"=>{
+#     "title"=>"The announcements", "pagination"=>"50"
+#     "emails"=>{"new_announcement"=>{"enabled"=>true}}                  # new
+#   },
 #  "course_forums_component"=>{"title"=>"chatterbox", "pagination"=>"50"},
 #  "course_leaderboard_component"=>
 #   {"title"=>"The leaderboard",
@@ -310,4 +538,29 @@ end
 #   {"pagination"=>"50",
 #    "braincert_whiteboard_api_key"=>"xxxxxxxxxxx",
 #    "max_duration"=>"60"},
+#                                                                        # below items are all unimplemented
+#  "course_assessments_component"=>{
+#    "Mission"=>{
+#      "columns"={"base_exp"=>{"header"=>"Your Reward"} ...},
+#      "datetime_format" => "ago",
+#      "emails"=>{"email_new_mission"=>{"enabled"=>true} ...},
+#      "allow_pdf_export"=>true,
+#    },
+#    "Training"=>{
+#      "columns"={"base_exp"=>{"visible"=>false} ...}
+#      "datetime_format" => "ago",
+#      "emails"=>{...},
+#      "allow_pdf_export"=>true,
+#      "multiple_choice_question_auto_grader_type"=>"two-one-zero",
+#      "reattempt_allowed"=>true
+#      "reattempt_percentage_earnable"=>"20"
+#    }
 #  }
+#  "course_users_component"=>{
+#    "title"=>"Custom Title",
+#    "allow_course_user_change_name"=>true,
+#    "emails"=>{...}
+#  },
+#  "course_achievements_component"=>{"show_greyscale_badge"=>false},
+#  "sidebar_assessments_submissions"=>{"title"=>"Custom Title"},
+#}


### PR DESCRIPTION
- Have structured assessments settings such that each category has its own settings, i.e. common assessments settings are duplicated for 'training' and 'mission' categories.
- In v1, each 'component' corresponds to one sidebar item, which is not the case in v2. Have migrated the v1 sidebarItem/component 'visible' flag to v2 component settings, not sidebar settings.

Settings for features not implemented (yet):
- Allow customization of assessment table for each assessment category - hide column, change header, change datetime format.
- Training features to support specific pedagogies
    - Two-One-Zero grader
    - Award fraction of experience points for re-attempts
- Allow user to control notification settings for emails
- Allow user to control what appears on course homepage
- Instead of showing lock icon for locked achievements, allow display of greyscale version of the badge.
- PDF export
- Allow students to change course user name

Fixes #30.